### PR TITLE
Fix feeding upgrade issues

### DIFF
--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/backpack/BackpackDataFixer.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/backpack/BackpackDataFixer.kt
@@ -1,0 +1,17 @@
+package com.cleanroommc.retrosophisticatedbackpacks.backpack
+
+import com.cleanroommc.retrosophisticatedbackpacks.inventory.ExposedItemStackHandler
+import net.minecraft.item.ItemFood
+import net.minecraft.item.ItemStack
+
+object BackpackDataFixer {
+    fun fixFeedingUpgrade(filterStacks: ExposedItemStackHandler) {
+        for (slotIndex in 0 until filterStacks.slots) {
+            val stack = filterStacks.getStackInSlot(slotIndex)
+
+            if (stack.item !is ItemFood) {
+                filterStacks.setStackInSlot(slotIndex, ItemStack.EMPTY)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/capability/upgrade/AdvancedFeedingUpgradeWrapper.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/capability/upgrade/AdvancedFeedingUpgradeWrapper.kt
@@ -1,5 +1,6 @@
 package com.cleanroommc.retrosophisticatedbackpacks.capability.upgrade
 
+import com.cleanroommc.retrosophisticatedbackpacks.backpack.BackpackDataFixer
 import com.cleanroommc.retrosophisticatedbackpacks.capability.Capabilities
 import com.cleanroommc.retrosophisticatedbackpacks.inventory.ExposedItemStackHandler
 import com.cleanroommc.retrosophisticatedbackpacks.item.FeedingUpgradeItem
@@ -41,7 +42,7 @@ class AdvancedFeedingUpgradeWrapper : AdvancedUpgradeWrapper<FeedingUpgradeItem>
             if (!checkFilter(stack))
                 continue
 
-            val item = stack.item as ItemFood
+            val item = stack.item as? ItemFood ?: continue
             val healingAmount = item.getHealAmount(stack)
 
             if (maxHealth > health && healthFeedingStrategy == FeedingStrategy.HEALTH.ALWAYS)
@@ -76,6 +77,7 @@ class AdvancedFeedingUpgradeWrapper : AdvancedUpgradeWrapper<FeedingUpgradeItem>
         super.deserializeNBT(nbt)
         hungerFeedingStrategy = FeedingStrategy.Hunger.entries[nbt.getByte(HUNGER_FEEDING_STRATEGY_TAG).toInt()]
         healthFeedingStrategy = FeedingStrategy.HEALTH.entries[nbt.getByte(HURT_FEEDING_STRATEGY_TAG).toInt()]
+        BackpackDataFixer.fixFeedingUpgrade(filterItems)
     }
 
     class FeedingStrategy private constructor() {

--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/capability/upgrade/FeedingUpgradeWrapper.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/capability/upgrade/FeedingUpgradeWrapper.kt
@@ -1,11 +1,13 @@
 package com.cleanroommc.retrosophisticatedbackpacks.capability.upgrade
 
+import com.cleanroommc.retrosophisticatedbackpacks.backpack.BackpackDataFixer
 import com.cleanroommc.retrosophisticatedbackpacks.capability.Capabilities
 import com.cleanroommc.retrosophisticatedbackpacks.inventory.ExposedItemStackHandler
 import com.cleanroommc.retrosophisticatedbackpacks.item.FeedingUpgradeItem
 import com.cleanroommc.retrosophisticatedbackpacks.util.Utils.asTranslationKey
 import net.minecraft.item.ItemFood
 import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.EnumFacing
 import net.minecraftforge.common.capabilities.Capability
 import net.minecraftforge.items.IItemHandler
@@ -30,7 +32,10 @@ class FeedingUpgradeWrapper : BasicUpgradeWrapper<FeedingUpgradeItem>(), IFeedin
             if (stack.isEmpty)
                 continue
 
-            if (checkFilter(stack))
+            val item = stack.item as? ItemFood ?: continue
+            val healingAmount = item.getHealAmount(stack)
+
+            if (healingAmount <= 20 - foodLevel && checkFilter(stack))
                 return handler.extractItem(i, 1, false)
         }
 
@@ -41,4 +46,9 @@ class FeedingUpgradeWrapper : BasicUpgradeWrapper<FeedingUpgradeItem>(), IFeedin
         capability == Capabilities.FEEDING_UPGRADE_CAPABILITY ||
                 super<IFeedingUpgrade>.hasCapability(capability, facing) ||
                 super<BasicUpgradeWrapper>.hasCapability(capability, facing)
+
+    override fun deserializeNBT(nbt: NBTTagCompound) {
+        super.deserializeNBT(nbt)
+        BackpackDataFixer.fixFeedingUpgrade(filterItems)
+    }
 }

--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/client/gui/BackpackPanel.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/client/gui/BackpackPanel.kt
@@ -245,6 +245,11 @@ class BackpackPanel(
                     tabWidget.expandedWidget = AdvancedFeedingUpgradeWidget(slotIndex, wrapper)
                 }
 
+                is FeedingUpgradeWrapper -> {
+                    upgradeSlotGroup.updateFilterDelegate(wrapper)
+                    tabWidget.expandedWidget = FeedingUpgradeWidget(slotIndex, wrapper)
+                }
+
                 is AdvancedFilterUpgradeWrapper -> {
                     upgradeSlotGroup.updateAdvancedFilterDelegate(wrapper)
                     tabWidget.expandedWidget = AdvancedFilterUpgradeWidget(slotIndex, wrapper)

--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/client/gui/widgets/AdvancedFeedingUpgradeWidget.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/client/gui/widgets/AdvancedFeedingUpgradeWidget.kt
@@ -37,11 +37,11 @@ class AdvancedFeedingUpgradeWidget(
 
         private val HEART_VARIANTS = listOf(
             CyclicVariantButtonWidget.Variant(
-                IKey.lang("gui.ignore_health".asTranslationKey()),
+                IKey.lang("gui.consider_health".asTranslationKey()),
                 RSBTextures.HALF_HEART_ICON
             ),
             CyclicVariantButtonWidget.Variant(
-                IKey.lang("gui.consider_health".asTranslationKey()),
+                IKey.lang("gui.ignore_health".asTranslationKey()),
                 RSBTextures.IGNORE_HALF_HEART_ICON
             ),
         )

--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/client/gui/widgets/FeedingUpgradeWidget.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/client/gui/widgets/FeedingUpgradeWidget.kt
@@ -1,0 +1,15 @@
+package com.cleanroommc.retrosophisticatedbackpacks.client.gui.widgets
+
+import com.cleanroommc.retrosophisticatedbackpacks.capability.upgrade.FeedingUpgradeWrapper
+import com.cleanroommc.retrosophisticatedbackpacks.item.Items
+import com.cleanroommc.retrosophisticatedbackpacks.util.Utils.asTranslationKey
+import net.minecraft.item.ItemStack
+
+class FeedingUpgradeWidget(slotIndex: Int, wrapper: FeedingUpgradeWrapper) :
+    BasicExpandedTabWidget<FeedingUpgradeWrapper>(
+        slotIndex,
+        wrapper,
+        ItemStack(Items.feedingUpgrade),
+        "gui.feeding_settings".asTranslationKey(),
+        filterSyncKey = "feeding_filter"
+    )


### PR DESCRIPTION
- Resolve #9.
- Fix endlessly feeding when basic variant is activated
- Fix advanced feeding upgrade's tab's button description

## For Players

This patch will automatically patch your basic feeding upgrade, however, for the patch to work normally, you'll have to place your backpack on ground and picks up. If this doesn't work, you may want to set yourself death to ensure player data doesn't interfere the patch.