### PR TITLE
Remove recursive player tick update

### DIFF
--- a/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/handler/EntityEventHandler.kt
+++ b/src/main/kotlin/com/cleanroommc/retrosophisticatedbackpacks/handler/EntityEventHandler.kt
@@ -141,7 +141,6 @@ object EntityEventHandler {
                     return
 
                 BackpackFeedingHelper.attemptFeed(player)
-                player.onUpdateEntity()
             }
         }
     }


### PR DESCRIPTION
Removes call to `EntityPlayerMP#onUpdateEntity()`, as this ends up firing `TickEvent.PlayerTickEvent` again. This can cause unexpected behavior for any mod that relies on the event to only fire once a tick. Doesn't cause an issue with RSB itself because it just advances the counter twice. Desyncs should have already been fixed by only feeding on the server-side.

An example of this causing an issue is where in a specific configuration, this would cause the mithminite robe (chestplate) from Thaumic Additions, which grants flight, inconsistently drop the player out of flight due to enabling then immediately removing flight capabilities on the same tick from receiving the player tick event twice.